### PR TITLE
Image Creation Change, Error Handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,11 @@
-FROM ubuntu:16.04
+FROM libpostal
 
-ARG COMMIT
-ENV COMMIT ${COMMIT:-master}
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y autoconf automake build-essential curl git libsnappy-dev libtool pkg-config
-
-RUN git clone https://github.com/openvenues/libpostal -b $COMMIT
-
 COPY ./*.go /libpostal/
-COPY ./*.sh /libpostal/
+COPY ./build_libpostal_api.sh /libpostal/
 
 WORKDIR /libpostal
-RUN ./build_libpostal.sh
 RUN ./build_libpostal_api.sh
 
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
-`libpostal-api.go` contains code for server.
-`Dockerfile` creates code for creating docker container, run as `docker build -t libpostal-api .` in the root directory of this repository.
-`build_libpostal.sh` and `build_libpostal_api.sh` contain simple bash instructions used during creation of docker image that install `libpostal` and necessary go packages.
+`libpostal-api.go` contains code for a server that accepts HTTP requests and returns the expanded or parsed address of what it is given using `libpostal`.
+
+To build the image...
+
+1) Go to `./base_image` and run `docker build -t libpostal .`. This builds a base image with `libpostal` already set up, which drastically cuts down on 
+2) Go to the root directory of the project and run `docker build -t libpostal-api .`. This will build the image that contains the 
+
+To run and test locally...
+
+1) `docker run -d -p 8080:8080 libpostal-api`
+2) Query locally via cURL with `curl -X POST -d '{"query": "1632 Washtenaw Ave"}' localhost:8080/libpostal/expand`, and the same for parse functionality, except with `parse` replacing `expand` at the end.
+
+To deploy a new version...
+
+1) First, check Google Container Registry's `libpostal-api` folder. Should tell you what version to tag the new image as.
+2) Tag the image appropriately by running `docker tag libpostal-api gcr.io/eminent-prism-112521/libpostal-api:[version]`.
+3) Go back to Google Container Registry. Remove the `latest` tag from the image that previously had it and add it to the new image.
+4) Find the `libpostal-api` workload on the `backend-cluster` in Kubernetes Engine and reboot it. Can be done a myriad of ways, I prefer scaling nodes to 0 and back up to 1.

--- a/base_image/Dockerfile
+++ b/base_image/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+
+ARG COMMIT
+ENV COMMIT ${COMMIT:-master}
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y autoconf automake build-essential curl git libsnappy-dev libtool pkg-config
+
+RUN git clone https://github.com/openvenues/libpostal -b $COMMIT
+
+COPY ./build_libpostal.sh /libpostal/
+
+WORKDIR /libpostal
+RUN ./build_libpostal.sh

--- a/base_image/build_libpostal.sh
+++ b/base_image/build_libpostal.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+./bootstrap.sh
+mkdir -p /opt/libpostal_data
+./configure --datadir=/opt/libpostal_data
+make
+make install
+ldconfig

--- a/build_libpostal.sh
+++ b/build_libpostal.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-./bootstrap.sh
-mkdir -p /opt/libpostal_data
-./configure --datadir=/opt/libpostal_data
-make
-make install
-ldconfig


### PR DESCRIPTION
Changes that allow construction of local container that runs all of the expensive build pieces, and then a separate container that uses that container as a base and simply adds the go packages/code and starts the server.

Also adds error handling to `libpostal-api.go` and changes paths to allow for use with `nginx-ingress` in Kubernetes cluster.